### PR TITLE
RangeError: Offset is outside the bounds of the DataView

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/stream.js
+++ b/src/stream.js
@@ -214,6 +214,10 @@ class Stream {
 
                 case FIT.BaseType.UINT32:
                 case FIT.BaseType.UINT32Z:
+                    if (dataView.buffer.byteLength === 1) {
+                        values.push(0);
+                        break
+                    }
                     values.push(dataView.getUint32(i * baseTypeSize, endianness));
                     break;
 


### PR DESCRIPTION
We are using this library to decode fit files from both Garmin and Coros devices. However, upon testing of Coros fit files, we encountered the below error

```
RangeError: Offset is outside the bounds of the DataView
        at DataView.getUint32 (<anonymous>)
        at Stream.getUint32 (/Users/walterholohan/Projects/rb-api/node_modules/@garmin-fit/sdk/src/stream.js:217:42)
        at Decoder.readValue (/Users/walterholohan/Projects/rb-api/node_modules/@garmin-fit/sdk/src/decoder.js:421:44)
        at Decoder.readRawFieldValue (/Users/walterholohan/Projects/rb-api/node_modules/@garmin-fit/sdk/src/decoder.js:408:37)
        at readFieldValue (/Users/walterholohan/Projects/rb-api/node_modules/@garmin-fit/sdk/src/decoder.js:333:56)
        at Array.forEach (<anonymous>)
        at Decoder.forEach (/Users/walterholohan/Projects/rb-api/node_modules/@garmin-fit/sdk/src/decoder.js:331:44)
        at Decoder.decodeMessage (/Users/walterholohan/Projects/rb-api/node_modules/@garmin-fit/sdk/src/decoder.js:233:26)
        at Decoder.decodeNextRecord (/Users/walterholohan/Projects/rb-api/node_modules/@garmin-fit/sdk/src/decoder.js:217:19)
        at Decoder.decodeNextFile [as read] (/Users/walterholohan/Projects/rb-api/node_modules/@garmin-fit/sdk/src/decoder.js:188:23)
```

Upon inspection of the Coros fit file, I could see that they have an empty 'Event' message (prob due to an error on their part) which is breaking the decoding. This PR will fix this by checking up the byte length is 1 and if so will return 0 instead of invoking the `dataView.getUint32()` function which was throwing the error.

Coros Fit File example:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/104106739/204500509-f0fbc431-acd7-4205-8a48-424978eba7f7.png">
