### PR TITLE
Fix syntax errors in Read Method documentation sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The Read method accepts an optional options object that can be used to customize
 
 ````js
 const { messages, errors } = decoder.read({
-    mesgListener = (messageNumber, message) => {},
+    mesgListener: (messageNumber, message) => {},
     applyScaleAndOffset: true,
     expandSubFields: true,
     expandComponents: true,
@@ -92,7 +92,7 @@ const onMesg = (messageNumber, message) => {
 }
 
 const { messages, errors } = decoder.read({
-    mesgListener = onMesg
+    mesgListener: onMesg
 });
 
 console.log(recordFields);


### PR DESCRIPTION
First off, thanks for providing an official FIT JavaScript SDK! 

This fixes a small typo in the documentation.