### PR TITLE
avoid superfluous copy of data

### DIFF
--- a/src/stream.js
+++ b/src/stream.js
@@ -112,10 +112,10 @@ class Stream {
             throw Error(`FIT Runtime Error end of stream at byte ${this.#position}`);
         }
 
-        const bytes = this.#arrayBuffer.slice(this.#position, this.#position + size);
+        const bytes = new Uint8Array(this.#arrayBuffer, this.#position, size);
         this.#position += size;
 
-        this.#crcCalculator?.addBytes(new Uint8Array(bytes), 0, size);
+        this.#crcCalculator?.addBytes(bytes, 0, size);
 
         return bytes;
     }
@@ -168,14 +168,14 @@ class Stream {
         const baseTypeSize = FIT.BaseTypeDefinitions[baseType].size;
         const baseTypeInvalid = FIT.BaseTypeDefinitions[baseType].invalid;
 
-        const arrayBuffer = this.readBytes(size);
+        const bytes = this.readBytes(size);
 
         if (size % baseTypeSize !== 0) {
             return convertInvalidToNull ? null : baseTypeInvalid;
         }
 
         if (baseType === FIT.BaseType.STRING) {
-            const string = this.#textDecoder.decode(arrayBuffer).replace(/\uFFFD/g, "");
+            const string = this.#textDecoder.decode(bytes).replace(/\uFFFD/g, "");
             const strings = string.split('\0');
 
             while (strings[strings.length - 1] === "") {
@@ -189,7 +189,7 @@ class Stream {
             return strings.length === 1 ? strings[0] : strings;
         }
 
-        const dataView = new DataView(arrayBuffer);
+        const dataView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
         let values = [];
 
         const count = size / baseTypeSize;


### PR DESCRIPTION
This change avoids a copy of data. When parsing a strava export containing 1100 fit.gz activities, the parsing time goes down from 22 seconds to 13 seconds with that change.