### PR TITLE
Update publish-npm.yml to use NodeJS v21

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 21
       - run: npm install --package-lock=false
       - run: npm test
 
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 21
           registry-url: https://registry.npmjs.org/
       - run: npm install --package-lock=false
       - run: npm publish


### PR DESCRIPTION
In order to build and test the SDK for publishing, it must use at least node version 21