### PR TITLE
Bug Fix: Correct Altitude and Component Field Encoding

### DIFF
--- a/src/encoder.js
+++ b/src/encoder.js
@@ -215,8 +215,16 @@ class Encoder {
                     throw new Error();
                 }
 
-                const scale = fieldDefinition.components.length > 1 ? FIELD_DEFAULT_SCALE : fieldDefinition.scale;
-                const offset = fieldDefinition.components.length > 1 ? FIELD_DEFAULT_OFFSET : fieldDefinition.offset;
+                let scale = fieldDefinition.components.length > 1 ? FIELD_DEFAULT_SCALE : fieldDefinition.scale;
+                let offset = fieldDefinition.components.length > 1 ? FIELD_DEFAULT_OFFSET : fieldDefinition.offset;
+
+                if (Array.isArray(scale)) {
+                    scale = scale[0];
+                }
+                if (Array.isArray(offset)) {
+                    offset = offset[0];
+                }
+
                 const hasScaleOrOffset = (scale != FIELD_DEFAULT_SCALE || offset != FIELD_DEFAULT_OFFSET);
 
                 if (hasScaleOrOffset) {

--- a/test/altitude-encoding.test.js
+++ b/test/altitude-encoding.test.js
@@ -1,0 +1,114 @@
+
+import { expect, test } from "vitest";
+import { Encoder, Decoder, Stream, Profile, Utils } from "../src/index.js";
+
+test("should encode and decode altitude correctly", () => {
+    const originalRecord = {
+        latitude: -37.85724407642275,
+        longitude: 145.12993351469538,
+        altitude: 116.4,
+        timestamp: 1751980229357,
+        distance: 10.2,
+        speed: 2,
+        grade: 2.3,
+        calories: 32,
+        heartRate: 72
+    };
+
+    const semicircles = {
+        latitude: originalRecord.latitude * (Math.pow(2, 31) / 180),
+        longitude: originalRecord.longitude * (Math.pow(2, 31) / 180),
+    };
+
+    const mesgs = [];
+    const now = new Date();
+    const startTime = Utils.convertDateToDateTime(now);
+
+    mesgs.push({
+        mesgNum: Profile.MesgNum.FILE_ID,
+        type: "activity",
+        manufacturer: "development",
+        product: 0,
+        timeCreated: startTime,
+        serialNumber: 1234,
+    });
+    
+    mesgs.push({
+        mesgNum: Profile.MesgNum.DEVICE_INFO,
+        deviceIndex: "creator",
+        manufacturer: "development",
+        product: 0,
+        productName: "Cookbook",
+        serialNumber: 1234,
+        softwareVersion: 1.0,
+        timestamp: startTime,
+    });
+
+    const recordMesg = {
+        mesgNum: Profile.MesgNum.RECORD,
+        timestamp: Utils.convertDateToDateTime(new Date(originalRecord.timestamp)),
+        positionLat: semicircles.latitude,
+        positionLong: semicircles.longitude,
+        altitude: originalRecord.altitude,
+        distance: originalRecord.distance,
+        speed: originalRecord.speed,
+        grade: originalRecord.grade,
+        calories: originalRecord.calories,
+        heartRate: originalRecord.heartRate,
+        enhancedAltitude: originalRecord.altitude,
+        enhancedSpeed: originalRecord.speed,
+    };
+    mesgs.push(recordMesg);
+
+    mesgs.push({
+        mesgNum: Profile.MesgNum.LAP,
+        messageIndex: 0,
+        timestamp: startTime + 1,
+        startTime: startTime,
+        totalElapsedTime: 1,
+        totalTimerTime: 1,
+    });
+
+    mesgs.push({
+        mesgNum: Profile.MesgNum.SESSION,
+        messageIndex: 0,
+        timestamp: startTime + 1,
+        startTime: startTime,
+        totalElapsedTime: 1,
+        totalTimerTime: 1,
+        sport: "walking",
+        subSport: "generic",
+        firstLapIndex: 0,
+        numLaps: 1,
+    });
+
+    mesgs.push({
+        mesgNum: Profile.MesgNum.ACTIVITY,
+        timestamp: startTime + 1,
+        numSessions: 1,
+        totalTimerTime: 1,
+    });
+    
+    const encoder = new Encoder();
+    mesgs.forEach((mesg) => {
+        encoder.writeMesg(mesg);
+    });
+    const fitFile = encoder.close();
+
+    const stream = Stream.fromBuffer(fitFile);
+    const decoder = new Decoder(stream);
+    const { messages, errors } = decoder.read();
+
+    expect(errors.length).toBe(0);
+
+    const decodedRecord = messages.recordMesgs[0];
+
+    expect(decodedRecord).toBeDefined();
+    expect(decodedRecord.altitude).toBeCloseTo(originalRecord.altitude, 1);
+    expect(decodedRecord.speed).toBeCloseTo(originalRecord.speed, 1);
+    expect(decodedRecord.grade).toBeCloseTo(originalRecord.grade, 1);
+    expect(decodedRecord.calories).toBeCloseTo(originalRecord.calories, 1);
+    expect(decodedRecord.heartRate).toBeCloseTo(originalRecord.heartRate, 1);
+    expect(decodedRecord.enhancedAltitude).toBeCloseTo(originalRecord.altitude, 1);
+    expect(decodedRecord.enhancedSpeed).toBeCloseTo(originalRecord.speed, 1);
+});


### PR DESCRIPTION
# Bug Fix: Correct Altitude and Component Field Encoding

This pull request addresses a bug in the JavaScript SDK's encoding logic, ensuring that altitude is handled correctly according to the FIT protocol specification.

## Description of Changes

1.  **Altitude Encoding Fix:** Corrected an issue in `encoder.js` where scale and offset values defined as arrays in the profile were not handled correctly, leading to improper calculations and corrupt data for fields like `altitude`.

---

### Incorrect Altitude Encoding

*   **Symptom:** When encoding a record with an `altitude` value (e.g., `116.4`), the value would be incorrectly encoded. After decoding, it would appear as a wildly different and invalid number (e.g., `-383.6`).

*   **Root Cause:** The field profile in `profile.js` defines `scale` and `offset` for `altitude` as arrays (`[5]` and `[500]`). The `#transformValue` function in `encoder.js` did not properly access the numeric value from these arrays, leading to incorrect string concatenation during the encoding calculation.

*   **Solution:** The `#transformValue` function in `encoder.js` was updated to check if `scale` or `offset` are arrays. If they are, it now correctly uses the first element of the array (e.g., `scale[0]`) for the calculation, ensuring the proper formula `(value + offset) * scale` is applied with the correct numeric values.

```javascript
// fit-javascript-sdk/src/encoder.js

// ...
let scale = fieldDefinition.components.length > 1 ? FIELD_DEFAULT_SCALE : fieldDefinition.scale;
let offset = fieldDefinition.components.length > 1 ? FIELD_DEFAULT_OFFSET : fieldDefinition.offset;

if (Array.isArray(scale)) {
    scale = scale[0];
}
if (Array.isArray(offset)) {
    offset = offset[0];
}

const hasScaleOrOffset = (scale != FIELD_DEFAULT_SCALE || offset != FIELD_DEFAULT_OFFSET);

if (hasScaleOrOffset) {
    const scaledValue = (value + offset) * scale;
// ...
```

### Testing

To validate this fix, the test file `fit-javascript-sdk/test/altitude-encoding.test.js` was created. It includes a comprehensive test case that:
*   Encodes a record with a known `altitude`.
*   Asserts that the decoded value for `altitude` matches the original input.
*   Asserts that the expanded `enhancedAltitude` component field is also correct.

All tests now pass, confirming that the bug has been resolved.